### PR TITLE
Use fixed version number prefix for Dependabot

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,7 +47,7 @@ jobs:
         VALID_VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+\.[0-9]+)?$"
 
         if [ "${{ github.actor }}" == "dependabot[bot]" ] ; then
-          VERSION=$(git describe --tags --abbrev=0)+dependabot.$(date '+%Y%m%d%H%M%S')
+          VERSION=v0.0.1-dependabot.$(date '+%Y%m%d%H%M%S')        
         elif [ ! -z "${MANUAL_VERSION}" ] ; then
           echo "User supplied version: ${MANUAL_VERSION}"
 


### PR DESCRIPTION
- Don't use `git describe` for version numbers for Dependabot PRs. Instead just use `v0.0.0-dependabot` + a timestamp